### PR TITLE
[서유림] Feat: 진행중인 레슨 페이지 UI 구현

### DIFF
--- a/src/components/ActiveLesson/ActiveEmpty.tsx
+++ b/src/components/ActiveLesson/ActiveEmpty.tsx
@@ -1,0 +1,11 @@
+import { img_progress_md } from "@/imageExports";
+import Image from "next/image";
+
+export default function ActiveEmpty() {
+  return (
+    <div className="flex flex-col gap-8 m-auto">
+      <Image src={img_progress_md} alt="active empty" />
+      <h1 className="text-gray-300 text-xl font-semibold">진행 중인 레슨이 없습니다.</h1>
+    </div>
+  );
+}

--- a/src/components/ActiveLesson/ActiveEmpty.tsx
+++ b/src/components/ActiveLesson/ActiveEmpty.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 export default function ActiveEmpty() {
   return (
     <div className="flex flex-col gap-8 m-auto">
-      <Image src={img_progress_md} alt="active empty" />
+      <Image src={img_progress_md} width={220} height={140} alt="active empty" />
       <h1 className="text-gray-300 text-xl font-semibold">진행 중인 레슨이 없습니다.</h1>
     </div>
   );

--- a/src/components/ActiveLesson/ActiveLessonSection.tsx
+++ b/src/components/ActiveLesson/ActiveLessonSection.tsx
@@ -1,0 +1,24 @@
+import clsx from "clsx";
+import ActiveLessonCard from "@/components/Cards/ActiveLessonCard";
+import ActiveEmpty from "./ActiveEmpty";
+
+const lesson_wrap = clsx(
+  "flex flex-col gap-8",
+  "p-16",
+  "border border-line-100 rounded-[4rem]",
+  "shadow-card bg-gray-50",
+);
+const lesson_title = "p-4 border-b border-line-200 text-2xl font-bold";
+
+export default function ActiveLessonSection({ title, items }: { title: string; items: string[] }) {
+  return (
+    <div className={lesson_wrap}>
+      <h1 className={lesson_title}>{title}</h1>
+      {items.length > 0 ? (
+        items.map((item, index) => <ActiveLessonCard key={index} item={item} />)
+      ) : (
+        <ActiveEmpty />
+      )}
+    </div>
+  );
+}

--- a/src/components/Cards/ActiveLessonCard.tsx
+++ b/src/components/Cards/ActiveLessonCard.tsx
@@ -1,0 +1,23 @@
+import CardContainer from "../Common/Card/CardContainer";
+import TrainerInfo from "../Common/Card/TrainerInfo/TrainerInfo";
+
+const description = "text-2xl font-semibold";
+/**
+ * 임시로 any 타입 지정
+ */
+export default function ActiveLessonCard({ item }: { item: any }) {
+  return (
+    <CardContainer width="100%" gap="1.6rem">
+      <div className="text-xl font-semibold">칩 넣을 자리</div>
+      <TrainerInfo
+        name="김강사"
+        rating={5}
+        reviewCount={23}
+        experience={4}
+        lessonCount={54}
+        isFavorited={true}
+        favoriteCount={34}
+      />
+    </CardContainer>
+  );
+}

--- a/src/pages/user/my-lesson/active-lesson/index.tsx
+++ b/src/pages/user/my-lesson/active-lesson/index.tsx
@@ -1,0 +1,16 @@
+import ActiveLessonSection from "@/components/ActiveLesson/ActiveLessonSection";
+
+export default function ActiveLesson() {
+  const items = new Array(1).fill("");
+  const items2 = new Array(0).fill("");
+
+  return (
+    <div className="flex max-w-[192rem] m-auto py-[6.4rem] bg-bg-100">
+      <div className="flex flex-col gap-8 max-w-[140rem] w-full m-auto">
+        <ActiveLessonSection title="재활운동" items={items} />
+        <ActiveLessonSection title="스포츠" items={items} />
+        <ActiveLessonSection title="피트니스" items={items2} />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## `수정한 파일`
- pages/user/my-lesson/active-lesson/index.tsx
- components/Cards/ActiveLessonCard.tsx
- components/ActiveLesson/ActiveLessonSection.tsx
- components/ActiveLesson/ActiveEmpty.tsx

## `작업 내역`
- - [x] 진행중인 레슨 페이지 UI 구현
- - [x] 진행중인 레슨 카드 템플릿 컴포넌트 UI 구현
- - [x] 진행중인 레슨 없을 시 표출되는 컴포넌트 구현

## `이미지`
![image](https://github.com/user-attachments/assets/b81ad802-55ef-4120-a2db-24dc611e239b)

## `참고 사항`
- UI만 구현하였습니다. 