### PR TITLE
[서유림] Feat: 견적 상세 페이지 기능 구현

### DIFF
--- a/src/components/Cards/FindTrainerCard.tsx
+++ b/src/components/Cards/FindTrainerCard.tsx
@@ -1,12 +1,22 @@
-import { LessonType } from "@/types/types";
+import { useQuery } from "@tanstack/react-query";
+import { getProfile } from "@/lib/api/authService";
+import { LessonType, Profile } from "@/types/types";
 import ChipLessonType from "../Chip/ChipLessonType";
 import CardContainer from "../Common/Card/CardContainer";
 import TrainerInfo from "../Common/Card/TrainerInfo/TrainerInfo";
 
-/**
- * 임시로 any 타입 지정
- */
-export default function FindTrainerCard({ item }: { item: any }) {
+export default function FindTrainerCard({ trainerId }: { trainerId: string }) {
+  const { data, isLoading, isError } = useQuery<Profile>({
+    queryKey: ["trainer-info", trainerId],
+    queryFn: () => getProfile(trainerId),
+  });
+
+  if (isLoading) return <div>로딩중</div>;
+  if (isError) return <div>에러 발생</div>;
+
+  /**
+   * @TODO favorite 정보 추가
+   */
   return (
     <CardContainer width="100%" gap="1.6rem">
       <div className="text-lg font-semibold">
@@ -14,13 +24,13 @@ export default function FindTrainerCard({ item }: { item: any }) {
       </div>
       <p className="text-md font-semibold pc:text-2xl">고객님에게 맞춤형 레슨을 해드립니다.</p>
       <TrainerInfo
-        name={item.name}
-        rating={item.rating}
-        reviewCount={item.reviewCount}
-        experience={item.experience}
-        lessonCount={item.lessonCount}
-        isFavorited={item.isFavorited}
-        favoriteCount={item.favoriteCount}
+        name={data?.name || ""}
+        rating={data?.rating || 0}
+        reviewCount={data?.reviewCount || 0}
+        experience={data?.experience || 0}
+        lessonCount={data?.lessonCount || 0}
+        isFavorited={true}
+        favoriteCount={23}
       />
     </CardContainer>
   );

--- a/src/components/Cards/FindTrainerCard.tsx
+++ b/src/components/Cards/FindTrainerCard.tsx
@@ -1,11 +1,18 @@
 import { useQuery } from "@tanstack/react-query";
 import { getProfile } from "@/lib/api/authService";
-import { LessonType, Profile } from "@/types/types";
+import { Quote } from "@/types/quote";
+import { LessonRequestStatus, LessonType, Profile } from "@/types/types";
 import ChipLessonType from "../Chip/ChipLessonType";
+import ChipRequestStatus from "../Chip/ChipRequestStatus";
 import CardContainer from "../Common/Card/CardContainer";
 import TrainerInfo from "../Common/Card/TrainerInfo/TrainerInfo";
 
-export default function FindTrainerCard({ trainerId }: { trainerId: string }) {
+interface FindTrainerCardProps {
+  quoteData: Quote;
+  trainerId: string;
+}
+
+export default function FindTrainerCard({ quoteData, trainerId }: FindTrainerCardProps) {
   const { data, isLoading, isError } = useQuery<Profile>({
     queryKey: ["trainer-info", trainerId],
     queryFn: () => getProfile(trainerId),
@@ -15,12 +22,13 @@ export default function FindTrainerCard({ trainerId }: { trainerId: string }) {
   if (isError) return <div>에러 발생</div>;
 
   /**
-   * @TODO favorite 정보 추가
+   * @TODO favorite 정보 추가 및 추가 데이터 입력
    */
   return (
     <CardContainer width="100%" gap="1.6rem">
-      <div className="text-lg font-semibold">
+      <div className="flex gap-[0.8rem] pc:gap-[1.2rem]">
         <ChipLessonType lessonType={LessonType.REHAB} size="lg" />
+        <ChipRequestStatus requestStatus={LessonRequestStatus.COMPLETED} size="lg" />
       </div>
       <p className="text-md font-semibold pc:text-2xl">고객님에게 맞춤형 레슨을 해드립니다.</p>
       <TrainerInfo

--- a/src/components/Common/QuoteInfo.tsx
+++ b/src/components/Common/QuoteInfo.tsx
@@ -1,4 +1,8 @@
 import clsx from "clsx";
+import { useQuery } from "@tanstack/react-query";
+import { getLessonInfo } from "@/lib/api/lessonService";
+import formatDate from "@/lib/utils/formatDate";
+import { Lesson } from "@/types/lesson";
 
 const content_area = clsx(
   "flex flex-col gap-[1.6rem]",
@@ -10,35 +14,38 @@ const content_wrap = "flex items-center gap-[3.2rem]";
 const label = "w-36 text-gray-300 text-md font-normal pc:text-2lg";
 const content = "text-md font-normal pc:text-2lg";
 
-/**
- *
- * @TODO data props로 받아와서 연결해야함
- */
+export default function QuoteInfo({ lessonRequestId }: { lessonRequestId: string }) {
+  const { data, isLoading, isError } = useQuery<Lesson>({
+    queryKey: ["trainer-info", lessonRequestId],
+    queryFn: () => getLessonInfo(lessonRequestId),
+  });
 
-export default function QuoteInfo() {
+  if (isLoading) return <div>로딩중</div>;
+  if (isError) return <div>견정 확정에 실패하였습니다.</div>;
+
   return (
     <div className="flex flex-col gap-[2.4rem] pc:gap-16">
       <p className="font-semibold text-lg pc:text-2xl">견적 정보</p>
       <div className={content_area}>
         <div className={content_wrap}>
           <p className={label}>견적 요청일</p>
-          <p className={content}>25.02.02</p>
+          <p className={content}>{formatDate(data.createdAt)}</p>
         </div>
         <div className={content_wrap}>
           <p className={label}>서비스 </p>
-          <p className={content}>스포츠</p>
+          <p className={content}>{data.lessonType}</p>
         </div>
         <div className={content_wrap}>
           <p className={label}>레슨 시작일</p>
-          <p className={content}>25.02.02</p>
+          <p className={content}>{data.startDate}</p>
         </div>
         <div className={content_wrap}>
           <p className={label}>레슨 종료일</p>
-          <p className={content}>25.02.12</p>
+          <p className={content}>{data.endDate}</p>
         </div>
         <div className={content_wrap}>
           <p className={label}>레슨 장소 </p>
-          <p className={content}>온라인</p>
+          <p className={content}>{data.locationType}</p>
         </div>
       </div>
     </div>

--- a/src/lib/api/lessonService.ts
+++ b/src/lib/api/lessonService.ts
@@ -24,3 +24,9 @@ export async function getReceiveRequest({
   });
   return res.data;
 }
+
+// 레슨 상세 조회
+export async function getLessonInfo(lessonId: string) {
+  const res = await get(`/lessons/${lessonId}`);
+  return res.data;
+}

--- a/src/lib/utils/formatPrice.ts
+++ b/src/lib/utils/formatPrice.ts
@@ -1,0 +1,3 @@
+export default function formatPrice(price: number) {
+  return price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}

--- a/src/pages/user/my-lesson/past-lesson/[id].tsx
+++ b/src/pages/user/my-lesson/past-lesson/[id].tsx
@@ -1,16 +1,65 @@
+import { GetServerSideProps } from "next";
+import { getQuote } from "@/lib/api/quoteService";
+import formatPrice from "@/lib/utils/formatPrice";
+import { Quote } from "@/types/quote";
 import FindTrainerCard from "@/components/Cards/FindTrainerCard";
 import { HorizontalLine } from "@/components/Common/Line";
 import QuoteInfo from "@/components/Common/QuoteInfo";
 import ShareSNS from "@/components/Common/ShareSNS";
 import Title from "@/components/Common/Title";
 
-export default function DetailPastLesson() {
+const data = {
+  id: "87691494-80e4-475c-8bda-a87d6a7bf001",
+  trainerId: "699fc386-d1a7-4430-a37d-9d1c5bdafd3f",
+  lessonRequestId: "6c3e95d6-0786-4cfb-9501-354ab8d527f1",
+  price: 200000,
+  message: "견적 요청드립니다. 긍정적인 검토 부탁드립니다.",
+  status: "COMPLETE",
+  rejectionReason: null,
+  createdAt: "2025-01-14T02:20:19.471Z",
+  updatedAt: "2025-01-14T02:20:19.471Z",
+};
+
+interface Props {
+  quoteInfo: Quote;
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  try {
+    /**
+     * @TODO 임시 id 지정
+     */
+    const quoteId = "1";
+    const quoteInfo = await getQuote(quoteId);
+
+    if (!quoteInfo) {
+      return {
+        notFound: true,
+      };
+    }
+
+    return {
+      props: {
+        quoteInfo,
+      },
+    };
+  } catch (err) {
+    console.error("Error fetching quote:", err);
+    return {
+      props: {
+        quoteInfo: null,
+      },
+    };
+  }
+};
+
+export default function DetailPastLesson({ quoteInfo }: Props) {
   return (
     <div className="flex flex-col gap-[1.6rem] pc:gap-[2.4rem]">
       <Title title="견적 상세" />
       <div className="flex flex-col w-full m-auto px-8 pc:flex-row pc:max-w-[140rem]">
         <div className="flex flex-col gap-[2.4rem] w-full pc:max-w-[95.5rem] pc:pr-[10rem] pc:gap-16">
-          <FindTrainerCard item="" />
+          <FindTrainerCard quoteData={data} trainerId={data.trainerId} />
           <div className="flex flex-col gap-4 pc:hidden">
             <HorizontalLine width="100%" />
             <ShareSNS label="견적서 공유하기" />
@@ -18,11 +67,11 @@ export default function DetailPastLesson() {
           <HorizontalLine width="100%" />
           <div className="flex flex-col gap-[1.6rem] pc:gap-[3.2rem]">
             <p className="text-lg font-semibold pc:text-2xl">견적가</p>
-            <p className="text-xl font-bold pc:text-3xl">180,000원</p>
+            <p className="text-xl font-bold pc:text-3xl">{formatPrice(data.price)}원</p>
           </div>
           <HorizontalLine width="100%" />
           <div className="flex flex-col gap-16">
-            <QuoteInfo />
+            <QuoteInfo lessonRequestId={data.lessonRequestId} />
           </div>
         </div>
         <div className="hidden pc:flex">

--- a/src/pages/user/my-lesson/pending-request/[id].tsx
+++ b/src/pages/user/my-lesson/pending-request/[id].tsx
@@ -87,7 +87,7 @@ export default function DetailPendingRequest({ quoteInfo }: Props) {
       <Title title="견적 상세" />
       <div className="flex flex-col w-full m-auto px-8 pc:flex-row pc:max-w-[140rem]">
         <div className="flex flex-col gap-[2.4rem] w-full pc:max-w-[95.5rem] pc:pr-[10rem] pc:gap-16">
-          <FindTrainerCard trainerId={data.trainerId} />
+          <FindTrainerCard quoteData={data} trainerId={data.trainerId} />
           <div className="flex flex-col gap-4 pc:hidden">
             <HorizontalLine width="100%" />
             <ShareSNS label="견적서 공유하기" />

--- a/src/pages/user/my-lesson/pending-request/[id].tsx
+++ b/src/pages/user/my-lesson/pending-request/[id].tsx
@@ -1,20 +1,93 @@
+import { GetServerSideProps } from "next";
+import { useMutation } from "@tanstack/react-query";
+import { acceptQuote, getQuote } from "@/lib/api/quoteService";
+import formatPrice from "@/lib/utils/formatPrice";
+import { Quote } from "@/types/quote";
 import FindTrainerCard from "@/components/Cards/FindTrainerCard";
 import Button from "@/components/Common/Button";
 import Favorite from "@/components/Common/Card/TrainerInfo/Favorite";
 import { HorizontalLine } from "@/components/Common/Line";
+import Loading from "@/components/Common/Loading";
 import QuoteInfo from "@/components/Common/QuoteInfo";
 import ShareSNS from "@/components/Common/ShareSNS";
 import Title from "@/components/Common/Title";
 
-const button = "h-[6.4rem] p-4 rounded-[1.6rem] font-semibold pc:text-xl";
+const data = {
+  id: "87691494-80e4-475c-8bda-a87d6a7bf001",
+  trainerId: "699fc386-d1a7-4430-a37d-9d1c5bdafd3f",
+  lessonRequestId: "6c3e95d6-0786-4cfb-9501-354ab8d527f1",
+  price: 200000,
+  message: "견적 요청드립니다. 긍정적인 검토 부탁드립니다.",
+  status: "PENDING",
+  rejectionReason: null,
+  createdAt: "2025-01-14T02:20:19.471Z",
+  updatedAt: "2025-01-14T02:20:19.471Z",
+};
 
-export default function DetailPendingRequest() {
+interface Props {
+  quoteInfo: Quote;
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  try {
+    /**
+     * @TODO 임시 id 지정
+     */
+    const quoteId = "1";
+    const quoteInfo = await getQuote(quoteId);
+
+    if (!quoteInfo) {
+      return {
+        notFound: true,
+      };
+    }
+
+    return {
+      props: {
+        quoteInfo,
+      },
+    };
+  } catch (err) {
+    console.error("Error fetching quote:", err);
+    return {
+      props: {
+        quoteInfo: null,
+      },
+    };
+  }
+};
+
+export default function DetailPendingRequest({ quoteInfo }: Props) {
+  const {
+    mutate: accept,
+    isLoading,
+    isError,
+  } = useMutation({
+    mutationFn: acceptQuote,
+    onSuccess: () => {
+      alert("견적이 확정되었습니다.");
+    },
+    onError: (err) => {
+      console.error("견적 확정 실패", err);
+      alert("견적 확정에 실패하였습니다.");
+    },
+  });
+
+  const handleAccept = () => {
+    if (quoteInfo && quoteInfo.id) {
+      accept(quoteInfo.id);
+    }
+  };
+
+  if (isLoading) return <Loading />;
+  if (isError) return <div>견정 확정에 실패하였습니다.</div>;
+
   return (
     <div className="flex flex-col gap-[1.6rem] pc:gap-[2.4rem]">
       <Title title="견적 상세" />
       <div className="flex flex-col w-full m-auto px-8 pc:flex-row pc:max-w-[140rem]">
         <div className="flex flex-col gap-[2.4rem] w-full pc:max-w-[95.5rem] pc:pr-[10rem] pc:gap-16">
-          <FindTrainerCard item="" />
+          <FindTrainerCard trainerId={data.trainerId} />
           <div className="flex flex-col gap-4 pc:hidden">
             <HorizontalLine width="100%" />
             <ShareSNS label="견적서 공유하기" />
@@ -22,19 +95,28 @@ export default function DetailPendingRequest() {
           <HorizontalLine width="100%" />
           <div className="flex flex-col gap-[1.6rem] pc:gap-[3.2rem]">
             <p className="text-lg font-semibold pc:text-2xl">견적가</p>
-            <p className="text-xl font-bold pc:text-3xl">180,000원</p>
+            <p className="text-xl font-bold pc:text-3xl">{formatPrice(data.price)}원</p>
           </div>
           <HorizontalLine width="100%" />
           <div className="flex flex-col gap-16">
-            <QuoteInfo />
+            <QuoteInfo lessonRequestId={data.lessonRequestId} />
           </div>
         </div>
         <div className="flex flex-col gap-16">
           <div className="flex flex-row gap-[0.8rem] p-4">
-            <Button className={`${button} w-[6.4rem] border border-line-200 bg-gray-50 pc:hidden`}>
+            <Button
+              className={
+                "h-[6.4rem] p-4 rounded-[1.6rem] font-semibold w-[6.4rem] border border-line-200 bg-gray-50 pc:text-xl pc:hidden"
+              }
+            >
               <Favorite />
             </Button>
-            <Button className={`${button} w-full text-gray-50 bg-blue-300 pc:w-[32.8rem]`}>
+            <Button
+              onClick={handleAccept}
+              className={
+                "h-[6.4rem] p-4 rounded-[1.6rem] font-semibold w-full text-gray-50 bg-blue-300 pc:text-xl pc:w-[32.8rem]"
+              }
+            >
               견적 확정하기
             </Button>
           </div>

--- a/src/types/quote.ts
+++ b/src/types/quote.ts
@@ -9,3 +9,15 @@ export interface QuoteParams {
   limit?: number;
   status?: string;
 }
+
+export interface Quote {
+  id: string;
+  trainerId: string;
+  lessonRequestId: string;
+  price: number;
+  message: string;
+  status: string;
+  rejectionReason?: string;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/src/types/quote.ts
+++ b/src/types/quote.ts
@@ -17,7 +17,7 @@ export interface Quote {
   price: number;
   message: string;
   status: string;
-  rejectionReason?: string;
+  rejectionReason?: string | null;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## `수정한 파일`
- pages/user/my-lesson/pending-request/[id].tsx
- pages/user/my-lesson/past-lesson/[id].tsx
- /Cards/FindTrainerCard.tsx
- /Common/QuoteInfo.tsx
- api/lessonService.ts
- utils/formatPrice.ts
- type/quote.ts

## `작업 내역`
- - [x] 대기중인 견적 상세 페이지 기능 구현
- - [x] 받았던 견적 상세 페이지 기능 구현
- - [x] 카드, 견적 정보에 데이터 연결
- - [x] 레슨 상세 조회 api 작성
- - [x] 가격 포맷 함수 작성
- - [x] 견적 타입 추가

## `참고 사항`
- 