### PR TITLE
[이강수] Update main.yml (CI/CD), and SNS-login fail handled

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,13 +14,16 @@ jobs: # 실행할 작업들을 정의하는 섹션
         uses: actions/checkout@v3 # GitHub 저장소 코드를 가져오는 공식 액션 사용
 
       - name: Build Docker image # Docker 이미지 빌드 단계
-        run: docker build --build-arg NEXT_PUBLIC_API_URL=${{ secrets.NEXT_PUBLIC_API_URL }} --build-arg NODE_ENV=${{ secrets.NODE_ENV }} --build-arg NEXT_PUBLIC_KAKAO_API_KEY=${{ secrets.NEXT_PUBLIC_KAKAO_API_KEY }} -t kipid/fitmate-fe:v0.1 . # Dockerfile을 사용하여 이미지 빌드, 태그는 v0.1로 지정
-
-      - name: Push Docker image to Docker Hub # Docker Hub에 이미지 푸시 단계
         run: |
           # Docker Hub 로그인 (보안을 위해 secrets 사용)
           docker login -u '${{ secrets.DOCKER_USERNAME }}' -p '${{ secrets.DOCKER_PASSWORD }}'
+          docker build --build-arg NEXT_PUBLIC_API_URL=${{ secrets.NEXT_PUBLIC_API_URL }} --build-arg NODE_ENV=${{ secrets.NODE_ENV }} --build-arg NEXT_PUBLIC_KAKAO_API_KEY=${{ secrets.NEXT_PUBLIC_KAKAO_API_KEY }} -t kipid/fitmate-fe:v0.1 . # Dockerfile을 사용하여 이미지 빌드, 태그는 v0.1로 지정
+
+      - name: Push Docker image to Docker Hub # Docker Hub에 이미지 푸시 단계
+        run: |
+          sleep 3
           docker push kipid/fitmate-fe:v0.1  # 빌드된 이미지를 Docker Hub에 업로드
+          docker logout
 
       - name: Deploy to server # 서버 배포 단계
         run: |
@@ -30,10 +33,12 @@ jobs: # 실행할 작업들을 정의하는 섹션
 
           # SSH를 통해 서버에 접속하여 배포 명령어 실행
           ssh -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key ${{ secrets.SERVER_USERNAME }}@${{ secrets.SERVER_IP }}  << 'EOF'
+            docker login -u '${{ secrets.DOCKER_USERNAME }}' -p '${{ secrets.DOCKER_PASSWORD }}'
             docker pull kipid/fitmate-fe:v0.1  # 최신 이미지 다운로드
             docker stop fitmate-fe-container || true  # 기존 컨테이너 중지 (실패해도 계속 진행)
             docker rm fitmate-fe-container || true  # 기존 컨테이너 제거 (실패해도 계속 진행)
             docker run -d -p 3001:3001 --name fitmate-fe-container --env-file /app/.env kipid/fitmate-fe:v0.1  # 새 컨테이너 실행
             sleep 5  # 컨테이너 실행 안정화 대기
             docker system prune -a  # 사용하지 않는 Docker 리소스 정리
+            docker logout
           EOF

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,12 +1,5 @@
 import { useSetUser, useUser } from "@/contexts/UserProvider";
-import {
-  ic_google_sm,
-  ic_kakao_sm,
-  ic_naver_sm,
-  ic_visibility_off,
-  ic_visibility_on,
-  logo_xl,
-} from "@/imageExports";
+import { ic_google_sm, ic_kakao_sm, ic_naver_sm, logo_xl } from "@/imageExports";
 import "dotenv/config";
 import Head from "next/head";
 import Image from "next/image";

--- a/src/pages/query-params-test.tsx
+++ b/src/pages/query-params-test.tsx
@@ -1,5 +1,4 @@
 import { GetServerSideProps } from "next";
-import { useSearchParams } from "next/navigation";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 

--- a/src/pages/sns-login.tsx
+++ b/src/pages/sns-login.tsx
@@ -1,51 +1,92 @@
 import { useSetUser } from "@/contexts/UserProvider";
+import { GetServerSideProps } from "next";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
+import toast from "react-hot-toast";
 import { Role } from "@/types/types";
 import Loading from "@/components/Common/Loading";
 
-function SNSLogIn() {
+interface QueryParams {
+  accessToken?: string;
+  refreshToken?: string;
+  user?: string;
+  hasProfile?: string;
+  message?: string;
+}
+
+interface PageProps {
+  initialQuery: QueryParams;
+}
+
+// 초기 로딩시 router.query 도 빈 JSON 객체이고, useSearchParams() 도 빈 JSON 객체이기 때문에 getServerSideProps 에서 초기값을 설정해 주어야 함.
+export const getServerSideProps: GetServerSideProps<PageProps> = async (context) => {
+  const {
+    accessToken = "",
+    refreshToken = "",
+    user = "",
+    hasProfile = "",
+    message = "",
+  } = context.query;
+
+  return {
+    props: {
+      initialQuery: {
+        accessToken: accessToken as string,
+        refreshToken: refreshToken as string,
+        user: user as string,
+        hasProfile: hasProfile as string,
+        message: message as string,
+      },
+    },
+  };
+};
+
+function SNSLogIn({ initialQuery }: PageProps) {
   const router = useRouter();
   const setUser = useSetUser();
 
-  useEffect(() => {
-    const query = new URLSearchParams(window.location.search);
-    const accessToken = query.get("accessToken");
-    const refreshToken = query.get("refreshToken");
-    const user = JSON.parse(query.get("user")!);
-    const hasProfileString = query.get("hasProfile") as string;
-    let hasProfile = false;
-    if (hasProfileString === "true") {
-      hasProfile = true;
-    }
+  const message = initialQuery?.message;
+  if (message) {
+    toast.error(message);
+  }
+  const accessToken = initialQuery?.accessToken;
+  const refreshToken = initialQuery?.refreshToken;
+  const user = JSON.parse(initialQuery?.user!);
+  const hasProfileString = initialQuery?.hasProfile;
+  let hasProfile = false;
+  if (hasProfileString === "true") {
+    hasProfile = true;
+  }
 
-    if (accessToken && refreshToken && user) {
-      localStorage.setItem(
-        "userData",
-        JSON.stringify({ accessToken, refreshToken, user, hasProfile }),
-      );
+  if (accessToken && refreshToken && user) {
+    localStorage.setItem(
+      "userData",
+      JSON.stringify({ accessToken, refreshToken, user, hasProfile }),
+    );
 
-      // 사용자 정보 업데이트
-      setUser({ ...user, hasProfile });
+    // 사용자 정보 업데이트
+    setUser({ ...user, hasProfile });
+    toast.success("로그인에 성공하였습니다.");
 
-      // 권한에 따라 페이지 이동
-      if (user.role === Role.USER) {
-        if (user.hasProfile) {
-          router.replace("/user/my-lesson/active-lesson");
-        } else {
-          router.replace("/user/profile/regist");
-        }
-      } else if (user.role === Role.TRAINER) {
-        if (user.hasProfile) {
-          router.replace("/trainer/received-request");
-        } else {
-          router.replace(`/trainer/${user.id}/profile/regist`);
-        }
+    // 권한에 따라 페이지 이동
+    if (user.role === Role.USER) {
+      if (user.hasProfile) {
+        router.replace("/user/my-lesson/active-lesson");
+      } else {
+        router.replace("/user/profile/regist");
       }
-    } else {
-      router.replace("/login");
+    } else if (user.role === Role.TRAINER) {
+      if (user.hasProfile) {
+        router.replace("/trainer/received-request");
+      } else {
+        router.replace(`/trainer/${user.id}/profile/regist`);
+      }
     }
-  }, [router, setUser]);
+  } else {
+    setTimeout(() => {
+      router.replace("/login");
+    }, 3000);
+  }
 
   return <Loading />;
 }


### PR DESCRIPTION
## `수정한 파일`
- .github/workflows/main.yml
- src/pages/sns-login.tsx

## `작업 내역`
- [x] build 전 login, 이후 logout. EC2 에서도 마지막엔 logout.
- [x] SNS-login 실패시 toast message 띄우고 login page 로 redirect 시키기.
